### PR TITLE
add idle_timeout to routes

### DIFF
--- a/client/components/FnRouteForm.vue
+++ b/client/components/FnRouteForm.vue
@@ -38,6 +38,12 @@
           <input type="number" class="form-control" placeholder="e.g. 60"  v-model="route.timeout" @keydown.enter.prevent="">
         </div>
       </div>
+      <div class="form-group">
+        <label class="col-sm-3 control-label">Idle Timeout, sec</label>
+        <div class="col-sm-9">
+          <input type="number" class="form-control" placeholder="e.g. 60"  v-model="route.idle_timeout" @keydown.enter.prevent="">
+        </div>
+      </div>
 
       <hr>
 

--- a/client/components/FnRouteForm.vue
+++ b/client/components/FnRouteForm.vue
@@ -23,25 +23,25 @@
       <div class="form-group">
         <label class="col-sm-3 control-label">Memory, MB</label>
         <div class="col-sm-9">
-          <input type="number" class="form-control" placeholder="e.g. 128"  v-model="route.memory" @keydown.enter.prevent="">
+          <input type="number" class="form-control" placeholder="e.g. 128"  v-model.number="route.memory" @keydown.enter.prevent="">
         </div>
       </div>
       <div class="form-group">
         <label class="col-sm-3 control-label">Max Concurrency</label>
         <div class="col-sm-9">
-          <input type="number" class="form-control" placeholder="e.g. 100"  v-model="route.max_concurrency" @keydown.enter.prevent="">
+          <input type="number" class="form-control" placeholder="e.g. 100"  v-model.number="route.max_concurrency" @keydown.enter.prevent="">
         </div>
       </div>
       <div class="form-group">
         <label class="col-sm-3 control-label">Timeout, sec</label>
         <div class="col-sm-9">
-          <input type="number" class="form-control" placeholder="e.g. 60"  v-model="route.timeout" @keydown.enter.prevent="">
+          <input type="number" class="form-control" placeholder="e.g. 60"  v-model.number="route.timeout" @keydown.enter.prevent="">
         </div>
       </div>
       <div class="form-group">
         <label class="col-sm-3 control-label">Idle Timeout, sec</label>
         <div class="col-sm-9">
-          <input type="number" class="form-control" placeholder="e.g. 60"  v-model="route.idle_timeout" @keydown.enter.prevent="">
+          <input type="number" class="form-control" placeholder="e.g. 60"  v-model.number="route.idle_timeout" @keydown.enter.prevent="">
         </div>
       </div>
 

--- a/client/pages/AppPage.vue
+++ b/client/pages/AppPage.vue
@@ -28,6 +28,7 @@
             <th>Memory</th>
             <th>MaxCC</th>
             <th>Timeout</th>
+            <th>Idle Timeout</th>
             <th width="140">Actions</th>
           </thead>
           <tbody>
@@ -38,6 +39,7 @@
               <td>{{route.memory}} MB</td>
               <td>{{route.max_concurrency}}</td>
               <td>{{route.timeout}}</td>
+              <td>{{route.idle_timeout}}</td>
               <td>
                 <div class="toolbar">
 


### PR DESCRIPTION
Add `idle_timeout` to functions ui for hot functions.

related to https://github.com/iron-io/functions/pull/663

~~currently doesn't work as it seems client is passing idle_timeout as string.~~
  
[using type transformations](https://github.com/vuejs/vue/issues/2002), it seems ok.